### PR TITLE
update project name to pydremio for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 packages = ["src/dremio"]
 
 [project]
-name = "dremio"
+name = "pydremio"
 version = "0.3.1"
 authors = [
   { name="Holger Zernetsch", email="6146286+holgerzer@users.noreply.github.com" },


### PR DESCRIPTION
This pull request includes a small but significant change to the `pyproject.toml` file. The project name has been updated from `dremio` to `pydremio` for pypi upload.